### PR TITLE
Fix for Whiteghost 4.0 on Heroku

### DIFF
--- a/sites/dev/heroku/wsgi.py
+++ b/sites/dev/heroku/wsgi.py
@@ -1,8 +1,6 @@
 import os
 from django.core.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sites.dev.heroku.settings")
 
 application = get_wsgi_application()
-application = DjangoWhiteNoise(application)

--- a/sites/settings.py
+++ b/sites/settings.py
@@ -38,6 +38,7 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware'
 )
 
 TEMPLATES = [


### PR DESCRIPTION
Hello.

I tried to deploy your demo project to Heroku, but the new version of whiteghost need some changes on configuration. 

I think this may be helpful.