### PR TITLE
Fix for Dockerfile smell DL3007

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,3 @@
 # Builds a Docker to deliver dist/
-FROM nginx:latest
+FROM nginx:1.23.4-bullseye
 COPY dist/ /usr/share/nginx/html


### PR DESCRIPTION
Hi!
The Dockerfile placed at "frontend/Dockerfile" contains the best practice violation [DL3007](https://github.com/hadolint/hadolint/wiki/DL3007) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3007 occurs when the tag "latest" is used instead of a specific version tag for the base image.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for the base image in order to replace the "latest" tag. In detail, it selects the most recent image tag which corresponds to the same image digest that currently corresponds to the "latest" tag.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance